### PR TITLE
Fix greedy replacement bug; only replace first match.

### DIFF
--- a/src/Language/Interpreter.php
+++ b/src/Language/Interpreter.php
@@ -88,7 +88,7 @@ class Interpreter extends TestMethodProvider
                     $method = $this->matcher->match($query[$i]);
 
                     // If anything was left over (for example parameters), grab them and insert them.
-                    $leftOver = str_ireplace($method->getOriginal(), '', $query[$i]);
+                    $leftOver = preg_replace("/{$method->getOriginal()}/i", '', $query[$i], 1);
                     $query[$i] = $method;
                     if (!empty($leftOver)) {
                         array_splice($query, $i + 1, 0, trim($leftOver));

--- a/tests/rules/issue_17_uppercase_letter.rule
+++ b/tests/rules/issue_17_uppercase_letter.rule
@@ -1,0 +1,6 @@
+srl: begin with (digit once), any of (letter, digit, uppercase letter) once or more, must end
+match: "1a"
+match: "56"
+match: "8B"
+no match: "abc"
+no match: "1"


### PR DESCRIPTION
This bug removed every following occurrence of a method, although it should only've removed the first one.

close #17